### PR TITLE
[GEM] Upgrade to mime-types 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    mime-types (2.99)
+    mime-types (3.2.2)
       mini_mime
 
 GEM
   remote: https://rubygems.org/
   specs:
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
 
 PLATFORMS
   ruby
@@ -16,4 +16,4 @@ DEPENDENCIES
   mime-types!
 
 BUNDLED WITH
-   1.16.1
+   1.17.0

--- a/lib/mime-types-shim/version.rb
+++ b/lib/mime-types-shim/version.rb
@@ -1,3 +1,3 @@
 module MimeTypesShim
-  VERSION = "2.99"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
This should allow us to upgrade to the latest httparty 0.16.3

httparty 0.16.2 does not need mime-types